### PR TITLE
Cron requires an update to pip

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.11
 RUN apk update && \
     apk add --no-cache docker-cli python3 && \
     apk add --no-cache --virtual .docker-compose-deps python3-dev libffi-dev openssl-dev gcc libc-dev make && \
+    pip3 install --upgrade pip && \
     pip3 install docker-compose && \
     apk del .docker-compose-deps
 


### PR DESCRIPTION
`docker-compose build` was failing when installing docker-compose with pip in the `cron` image. Just updating pip before running the command fixes this (as updating pip usually does!).