### PR TITLE
Don't leak _arg values into next domain

### DIFF
--- a/certbot/certbot-certonly.sh
+++ b/certbot/certbot-certonly.sh
@@ -34,11 +34,15 @@ for domain in $domains; do
   if [ "$www_subdomain" = "true" ]; then
     www_subdomain_arg="-d www.${domain}"
     echo "A 'www' subdomain enabled"
+  else
+    www_subdomain_arg=""
   fi
 
   if [ "$test_cert" = "true" ]; then
     test_cert_arg="--test-cert"
     echo "Testing on staging environment enabled"
+  else
+    test_cert_arg=""
   fi
 
   if [ -z "$email" ]; then


### PR DESCRIPTION
If one domain has `www_subdomain` set to true, the next domain with `www_subdomain` set to false would inherit the `www_subdomain_arg` value from the first. This fixes that.